### PR TITLE
Set classification and tier

### DIFF
--- a/.teamsnap/service.yml
+++ b/.teamsnap/service.yml
@@ -1,15 +1,18 @@
 ---
-classification: 
+classification: lib
 production:
-  tier: 
+  tier: 3
   url: 
   hosting_platform: 
-  logging: false
 performance_monitoring: []
 error_monitoring: []
 continuous_integration: []
 bug_tracking: []
 documentation: []
 deployment: []
-languages: []
-frameworks: []
+languages:
+  - name: JavaScript
+frameworks:
+  - name: React
+    version: 16.13.1
+logging: []

--- a/.teamsnap/service.yml
+++ b/.teamsnap/service.yml
@@ -3,7 +3,7 @@ classification: lib
 production:
   tier: 3
   url: 
-  hosting_platform: 
+  hosting_platform: Vercel
 performance_monitoring: []
 error_monitoring: []
 continuous_integration: []

--- a/.teamsnap/service.yml
+++ b/.teamsnap/service.yml
@@ -1,5 +1,5 @@
 ---
-classification: lib
+classification: webapp
 production:
   tier: 3
   url: 


### PR DESCRIPTION
For Platform Triage: https://paper.dropbox.com/doc/Platform-Triage-Action-Log--A_JteAc~bTcxz8WkgMXwUeJPAg-v3oHew26vdKsIljZeCtYZ

This is a webapp that runs locally, I think?  Therefore it does not need observability and I classified it as a lib. That doesn't feel quite right, maybe "internal webapp" or "tool" would be an appropriate new classification?