### PR TITLE
chore(deps): group dependabot patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "12:00"
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 5
-  rebase-strategy: disabled
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "12:00"
+    pull-request-branch-name:
+      separator: "-"
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"


### PR DESCRIPTION
This will make dependabot group all dependency patch updates into a single PR, rather than one for each dependency.